### PR TITLE
Fixed to test case 01.12 -- now it passes, yay!

### DIFF
--- a/validation/test_cases/01_BasicSettingTestCases.md
+++ b/validation/test_cases/01_BasicSettingTestCases.md
@@ -112,6 +112,6 @@ Use the function `optimal_normal()`. Supply the same input values as in test cas
 Verify that the function calculates an optimal sample size of 78 in phase II, an expected utility of 944 (in 10^5\$)  and an optimal threshold value of 0.12 as suggested by Stella Erdmann [2]. Furthermore, verify that the probability of a successful program is given by 0.83, which is the sum of the probabilities of a small (0.51), medium (0.30) or large (0.02) treatment effect.
 
 ### 01.12 (shows that req. 01.08 is met): {-}
-Use the `function optimal_tte`. Supply the same input values as in test case 01.01 to the function except for the following change: Set the number of cores for parallel computing to 1. Verify that the computation time will increase compared to the setting in 01.02.
+Use the `function optimal_tte`. Supply the same input values as in test case 01.01 to the function except for the following change: Set the number of cores for parallel computing to 1. Verify that the computation time will increase compared to the setting in 01.01.
 
 

--- a/validation/test_code/01_BasicSettingTestCode.R
+++ b/validation/test_code/01_BasicSettingTestCode.R
@@ -333,7 +333,7 @@ test_that("01.12", {
   res = optimal_tte(
     alpha = 0.025, # significance level
     beta = 0.1, # 1 - power
-    hr1 = 0.8, hr2 = NULL, # assumed treatment effects
+    hr1 = 0.69, hr2 = 0.88, # assumed treatment effects
     xi2 = 0.7, xi3 = 0.7, # event rates
     d2min = 10, d2max = 400, stepd2 = 1, # optimization region for the number of events
     hrgomin = 0.71, hrgomax = 0.95, stephrgo = 0.01, # optimization
@@ -344,19 +344,18 @@ test_that("01.12", {
     num_cl = 3, # number of clusters
     c02 = 100, c03 = 150, # fixed cost for phase II and phase III
     c2 = 0.75, c3 = 1, # variable per-patient cost in phase II and phase III
-    fixed = TRUE, # use a prior distribution
-    w = NULL, # weight for the prior distribution
-    id1 = NULL, id2 = NULL, # amount of information (number of events) for prior
+    fixed = FALSE, # use a prior distribution
+    w = 0.3, # weight for the prior distribution
+    id1 = 210, id2 = 420, # amount of information (number of events) for prior
     # true treatment effect
   )
   end_time_3 = Sys.time()
   time_elapsed_01_02_num_cl_3 = end_time_3 - start_time_3
   start_time_1 = Sys.time()
-  # Time to event with fixed treatment effects
   res = optimal_tte(
     alpha = 0.025, # significance level
     beta = 0.1, # 1 - power
-    hr1 = 0.69, hr2 = 0.80, # assumed treatment effects
+    hr1 = 0.69, hr2 = 0.88, # assumed treatment effects
     xi2 = 0.7, xi3 = 0.7, # event rates
     d2min = 10, d2max = 400, stepd2 = 1, # optimization region for the number of events
     hrgomin = 0.71, hrgomax = 0.95, stephrgo = 0.01, # optimization
@@ -367,9 +366,9 @@ test_that("01.12", {
     num_cl = 1, # number of clusters
     c02 = 100, c03 = 150, # fixed cost for phase II and phase III
     c2 = 0.75, c3 = 1, # variable per-patient cost in phase II and phase III
-    fixed = TRUE, # use a prior distribution
-    w = NULL, # weight for the prior distribution
-    id1 = NULL, id2 = NULL, # amount of information (number of events) for prior
+    fixed = FALSE, # use a prior distribution
+    w = 0.3, # weight for the prior distribution
+    id1 = 210, id2 = 420, # amount of information (number of events) for prior
     # true treatment effect
   )
   end_time_1 = Sys.time()


### PR DESCRIPTION
It seems that for small computation times (duration ca. 10s), parallel computing takes slightly longer. However, when we choose longer calculations (e.g. fixed = FALSE, duration ca. 2 min), parallel computing is quicker.